### PR TITLE
stopID caching to prevent excessive findStop calls

### DIFF
--- a/MMM-DVB.js
+++ b/MMM-DVB.js
@@ -142,13 +142,11 @@ Module.register("MMM-DVB", {
     },
 
     start: function() {
-        Log.info("Starting module: " + this.name);
-        this.request(this);
-        setInterval(this.request, this.config.reload, this);
+        Log.info("Starting module: " + this.identifier);
+        this.sendSocketNotification("REGISTER-MODULE", this.identifier);
     },
 
     request: function(self) {
-
         var request = {
             id: self.identifier,
             stopName: self.config.stopName,
@@ -162,7 +160,11 @@ Module.register("MMM-DVB", {
     },
 
     socketNotificationReceived: function(notification, payload) {
-        if (notification === "DVB-RESPONSE" && payload.id === this.identifier) {
+        if (notification === "REGISTER-ACK" && payload === this.identifier) {
+            Log.log("Module registered: " + payload);
+            this.request(this);
+            var interval = setInterval(this.request, this.config.reload, this);
+        } else if (notification === "DVB-RESPONSE" && payload.id === this.identifier) {
             Log.log("Response: " + JSON.stringify(payload));
             this.dvb_data = payload.connections;
             this.updateDom();

--- a/node_helper.js
+++ b/node_helper.js
@@ -11,7 +11,6 @@ module.exports = NodeHelper.create({
     monitor: function(payload) {
         var self = this;
         dvb.monitor(this.stop.id, payload.timeOffset, this.numberOfRequestedResults(payload)).then((data) => {
-            console.log('Monitoring stop departures...');
             var response = {
                 id: payload.id,
                 connections: self.connectionsToBeDisplayed(data, payload)
@@ -21,7 +20,7 @@ module.exports = NodeHelper.create({
     },
     findStop: function(payload) {
         var self = this;
-        console.log('Searching stop ID...');
+        Log.log("Searching stop ID for: " + payload.stopName);
         dvb.findStop(payload.stopName).then((data) => {
             if (Array.isArray(data) && data.length > 0) {
                 self.stop.id = data[0].id;

--- a/node_helper.js
+++ b/node_helper.js
@@ -31,18 +31,21 @@ module.exports = NodeHelper.create({
     },
     socketNotificationReceived: function(notification, payload) {
         var self = this;
-        if (notification === 'REGISTER-MODULE') {
-            self.stop[payload] = {
-                id: {},
-                name: {}
-            };
-            self.sendSocketNotification("REGISTER-ACK", payload);
-        } else if (notification === 'DVB-REQUEST') {
-            if (!self.stop[payload.id].id || self.stop[payload.id].name != payload.stopName) {
-                self.findStop(payload);
-            } else {
-                self.monitor(payload);
-            }
+        switch (notification) {
+            case 'REGISTER-MODULE':
+                self.stop[payload] = {
+                    id: {},
+                    name: {}
+                };
+                self.sendSocketNotification("REGISTER-ACK", payload);    
+                break;
+            case 'DVB-REQUEST':
+                if (!self.stop[payload.id].id || self.stop[payload.id].name != payload.stopName) {
+                    self.findStop(payload);
+                } else {
+                    self.monitor(payload);
+                }
+                break;
         }
     },
     numberOfRequestedResults: function(payload) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -6,11 +6,11 @@ module.exports = NodeHelper.create({
 
     start: function() {
         Log.log("Starting node helper for: " + this.name);
-        this.stopID = "";
+        this.stop = {};
     },
     monitor: function(payload) {
         var self = this;
-        dvb.monitor(this.stopID, payload.timeOffset, this.numberOfRequestedResults(payload)).then((data) => {
+        dvb.monitor(this.stop.id, payload.timeOffset, this.numberOfRequestedResults(payload)).then((data) => {
             console.log('Monitoring stop departures...');
             var response = {
                 id: payload.id,
@@ -24,7 +24,8 @@ module.exports = NodeHelper.create({
         console.log('Searching stop ID...');
         dvb.findStop(payload.stopName).then((data) => {
             if (Array.isArray(data) && data.length > 0) {
-                self.stopID = data[0].id;
+                self.stop.id = data[0].id;
+                self.stop.name = payload.stopName;
                 self.monitor(payload);
             }
         });
@@ -32,7 +33,7 @@ module.exports = NodeHelper.create({
     socketNotificationReceived: function(notification, payload) {
         if (notification === 'DVB-REQUEST') {
             var self = this;
-            if (!self.stopID) {
+            if (!self.stop.id || self.stop.name != payload.stopName) {
                 self.findStop(payload);
             } else {
                 self.monitor(payload);

--- a/node_helper.js
+++ b/node_helper.js
@@ -32,7 +32,10 @@ module.exports = NodeHelper.create({
     socketNotificationReceived: function(notification, payload) {
         var self = this;
         if (notification === 'REGISTER-MODULE') {
-            self.stop[payload] = {id:{}, name:{}};
+            self.stop[payload] = {
+                id: {},
+                name: {}
+            };
             self.sendSocketNotification("REGISTER-ACK", payload);
         } else if (notification === 'DVB-REQUEST') {
             if (!self.stop[payload.id].id || self.stop[payload.id].name != payload.stopName) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -17,7 +17,7 @@ module.exports = NodeHelper.create({
                 connections: self.connectionsToBeDisplayed(data, payload)
             };
             self.sendSocketNotification("DVB-RESPONSE", response);
-        }); 
+        });
     },
     findStop: function(payload) {
         var self = this;
@@ -37,7 +37,7 @@ module.exports = NodeHelper.create({
                 self.findStop(payload);
             } else {
                 self.monitor(payload);
-            };   
+            }
         }
     },
     numberOfRequestedResults: function(payload) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -32,11 +32,9 @@ module.exports = NodeHelper.create({
     socketNotificationReceived: function(notification, payload) {
         var self = this;
         if (notification === 'REGISTER-MODULE') {
-            Log.log("Registration request received from: " + payload);
             self.stop[payload] = {id:{}, name:{}};
             self.sendSocketNotification("REGISTER-ACK", payload);
         } else if (notification === 'DVB-REQUEST') {
-            Log.log("Received request from: " + payload.id);
             if (!self.stop[payload.id].id || self.stop[payload.id].name != payload.stopName) {
                 self.findStop(payload);
             } else {


### PR DESCRIPTION
The current implementation (IMHO) generates excessive requests to `dvb.findStop()` method, as it is not really required to search for a station ID during every update request. 
As per my understanding, we need to get `stopID` when:
- The module is starting.
- A user has changed the config and inserted new/other stop.

Therefore, I added intermediate storing mechanism for `stopID` and `stopName`. 
`stopID` searching is triggered only in above mentioned two cases, otherwise only `dvb.monitor()` is triggered. 